### PR TITLE
Eliminate some shifting of signed integers.

### DIFF
--- a/ym3438.c
+++ b/ym3438.c
@@ -30,6 +30,8 @@
 #include <string.h>
 #include "ym3438.h"
 
+#define SIGN_EXTEND(bit_index, value) (((value) & ((1u << (bit_index)) - 1u)) - ((value) & (1u << (bit_index))))
+
 enum {
     eg_num_attack = 0,
     eg_num_decay = 1,
@@ -972,8 +974,7 @@ static void OPN2_ChOutput(ym3438_t *chip)
     if (((cycles >> 2) == 1 && chip->dacen) || test_dac)
     {
         out = (Bit16s)chip->dacdata;
-        out <<= 7;
-        out >>= 7;
+        out = SIGN_EXTEND(8, out);
     }
     else
     {
@@ -1059,8 +1060,7 @@ static void OPN2_FMGenerate(ym3438_t *chip)
     {
         output = output ^ (chip->mode_test_21[4] << 13);
     }
-    output <<= 2;
-    output >>= 2;
+    output = SIGN_EXTEND(13, output);
     chip->fm_out[slot] = output;
 }
 


### PR DESCRIPTION
In C, shifting a signed integer does not have standard well-defined behaviour: right-shifting *could* 'shift in' a copy of the sign bit, or it could not.

https://stackoverflow.com/questions/4009885/arithmetic-bit-shift-on-a-signed-integer

Shifting signed integers is used in at least two places in the codebase in order to perform sign-extension. To avoid the use of shifting, sign extension is now instead achieved with two ANDs and a subtraction. The behaviour of this logic should be consistent across all platforms, improving this library's portability.