### PR TITLE
Eliminate more shifting of signed integers.

### DIFF
--- a/ym3438.c
+++ b/ym3438.c
@@ -884,7 +884,7 @@ static void OPN2_FMPrepare(ym3438_t *chip)
     if (op == 0)
     {
         /* Feedback */
-        mod = mod >> (10 - chip->fb[channel]);
+        mod = mod / (1 << (10 - chip->fb[channel]));
         if (!chip->fb[channel])
         {
             mod = 0;
@@ -892,7 +892,7 @@ static void OPN2_FMPrepare(ym3438_t *chip)
     }
     else
     {
-        mod >>= 1;
+        mod /= 2;
     }
     chip->fm_mod[slot] = mod;
 


### PR DESCRIPTION
To be honest, this might be a vain effort: there are many more cases of shifting signed integers throughout the codebase, and GCC considers them such a non-issue that it doesn't even have an option for producing compiler warnings when they happen. This might just be one of those cases of something that technically is against the C standard but doesn't harm portability to any significant degree (like assuming that negative signed integers are expressed in binary as two's complement).